### PR TITLE
chore: remove Release Checklist from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,12 +14,6 @@ Links to any open tickets.
 
 List any breaking changes here and tag the relevant engineer.
 
-### Release Checklist ###
-
-- [ ] Security and Functional QA Passed 
-- [ ] Double-Checked Target Branch
-- [ ] E2E Automation Tests Ran
-
 ### Notes ###
 
 Any notes to reviewers go here.


### PR DESCRIPTION
## Summary
- Removes the Release Checklist section from the org-wide PR template
- The checklist items (QA, target branch, E2E tests) are better handled through CI/CD automation rather than manual checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template to streamline the contribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->